### PR TITLE
add test for extraction into directory with no write perms

### DIFF
--- a/getting-credits/2025/tests/test-033.sh
+++ b/getting-credits/2025/tests/test-033.sh
@@ -1,0 +1,16 @@
+#/usr/bin/env bash
+#
+# Extract test with insufficient permissions to write.
+
+source $configvar
+cd $tmpdir
+
+typeset -i last=${#inputfiles[@]}
+
+tmp2=noperms-$(basename $0)
+mkdir "$tmp2" || { echo "mkdir failed" && exit 1; }
+cd "$tmp2"
+chmod -w .
+
+$MYTAR -x -f "../$tarfile"
+(($? == 2)) || exit 1

--- a/getting-credits/2025/tests/test-output-033.txt
+++ b/getting-credits/2025/tests/test-output-033.txt
@@ -1,0 +1,10 @@
+mytar: aaa-file: Cannot open: Permission denied
+mytar: another-file2: Cannot open: Permission denied
+mytar: empty.data: Cannot open: Permission denied
+mytar: file.zero: Cannot open: Permission denied
+mytar: file1.random: Cannot open: Permission denied
+mytar: file2.zero: Cannot open: Permission denied
+mytar: file3.zero: Cannot open: Permission denied
+mytar: hello-world: Cannot open: Permission denied
+mytar: small-file: Cannot open: Permission denied
+mytar: Exiting with failure status due to previous errors


### PR DESCRIPTION
I noticed missing checks for the `fopen()` call used for extraction in some of the handouts. This supplies such test.

Filing this as a PR since the task evaluation is in progress right now and it would not be fair to change the tests. If the tar is still used next year, it could be considered.